### PR TITLE
Removed Hackaday

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# kwak_test.github.io
+# kwak_pi_list.github.io
+
+
+This is a modified version of smokingwheels/smokingwheels.github.io
+Mostly because I wanted to remove hackaday from being blocked.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# smokingwheels.github.io
+# kwak_test.github.io

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# the-kwak.github.io
+# the-kwak.github.io/kwaks_mods_smokingwheels
 
 
 This is a modified version of smokingwheels.github.io

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# kwak_pi_list.github.io
+# the-kwak.github.io
 
 
-This is a modified version of smokingwheels/smokingwheels.github.io
+This is a modified version of smokingwheels.github.io
 Mostly because I wanted to remove hackaday from being blocked.


### PR DESCRIPTION
Hackaday is a blogging site about hacking electronics to meet your needs not a site that should be on any sort of blocking list